### PR TITLE
Use `grep "inet "` to prevent getting IPv6 addresses

### DIFF
--- a/NJUPT-AutoLogin.sh
+++ b/NJUPT-AutoLogin.sh
@@ -45,7 +45,7 @@ help() {
 }
 
 logout() {
-  ip=$(ifconfig "${eth}" | grep inet | awk '{print $2}' | tr -d "addr:")
+  ip=$(ifconfig "${eth}" | grep "inet " | awk '{print $2}' | tr -d "addr:")
 	if [ ! "$ip" ]
 	then
 		printf "获取ip地址失败\n"
@@ -165,7 +165,7 @@ loginNet() {
 		exit 0
 	fi
 
-	ip=$(ifconfig "${eth}" | grep inet | awk '{print $2}' | tr -d "addr:")
+	ip=$(ifconfig "${eth}" | grep "inet " | awk '{print $2}' | tr -d "addr:")
 	if [ ! "$ip" ]
 	then
 		printf "获取ip地址失败\n"


### PR DESCRIPTION
If the interface have IPv6 addrs:
```
ethx: flags=xxxx<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.165.xxx.xxx  netmask 255.255.128.0  broadcast 10.162.255.255
        inet6 2001:da8:1032:6004::xxxx  prefixlen 128  scopeid 0x0<global>
        inet6 fe80::xxxx:xxxx:xxxx:xxxx  prefixlen 64  scopeid 0x20<link>
```
The script will not work properly:
```
无法判断网络状态，尝试登录
当前设备的ip地址为10.165.xxx.xxx
2001810326004xxxx
fe80xxxxxxxxxxx
运营商为电信
curl: (3) URL rejected: Malformed input to a URL function

接口请求错误：
如果问题持续出现，请在GitHub上提交Issue
```
This PR fixes this.