### PR TITLE
feat: automatically match WAN interface name in OpenWRT environment

### DIFF
--- a/NJUPT-AutoLogin.sh
+++ b/NJUPT-AutoLogin.sh
@@ -41,7 +41,29 @@ sysenv="$(uname)"
 login_id=""
 login_pw=""
 isp="ctcc"
-interface="en0"
+
+get_default_interface() {
+	local def_if="eth0"
+	if [[ -f "/etc/os-release" ]]; then
+		# shellcheck source=/dev/null
+		. /etc/os-release
+		if [[ "$NAME" == "OpenWrt" ]] || [[ "$NAME" == "ImmortalWrt" ]]; then
+			if command -v uci >/dev/null 2>&1; then
+				local wan_if
+				wan_if=$(uci -q get network.wan.device)
+				if [[ -z "$wan_if" ]]; then
+					wan_if=$(uci -q get network.wan.ifname)
+				fi
+				if [[ -n "$wan_if" ]]; then
+					def_if="$wan_if"
+				fi
+			fi
+		fi
+	fi
+	printf "%s" "$def_if"
+}
+
+interface=$(get_default_interface)
 timeout=2
 time_unlimited_account=1
 logout_flag=1

--- a/README.md
+++ b/README.md
@@ -90,14 +90,12 @@ Linux 使用此脚本前需要检查以下依赖是否安装：
 
 下载 [Releases](https://github.com/s235784/NJUPT_AutoLogin/releases) 中的脚本，上传到路由器中。
 
-进入路由器后台，记住首页出现的 **IPv4 WAN 状态** 中的 **`eth0.x`**，例如我这里是 `eth0.2`。
-
-![readme_openwrt_eth](doc/readme_openwrt_eth.png)
+脚本已支持自动检测 OpenWrt 的 WAN 接口名称（如 `wan` 或 `eth0.x`），通常情况下**无需手动指定 `-i` 参数**。
 
 在路由器的计划任务中添加以下命令，并根据实际情况修改这条命令（复杂的密码请用 `"` 括起来）：
 
 ```crontab
-*/5 * * * * bash /path/to/your/NJUPT-AutoLogin.sh [-i interface] [-I isp] [-t timeout] [-p ipv4_addr] [-r restart_device] [-T sleep_time] [-6] [-m] [-n] [-c] [-l] [-v] login_id login_password
+*/5 * * * * bash /path/to/your/NJUPT-AutoLogin.sh [-I isp] [-t timeout] [-p ipv4_addr] [-r restart_device] [-T sleep_time] [-6] [-m] [-n] [-c] [-l] [-v] login_id login_password
 ```
 
 确认无误后保存。之后路由器就会每 5 分钟确认一次网络状态，如果允许登录时间内没有登录校园网，路由器就会自动尝试登录了。


### PR DESCRIPTION
因为 OpenWrt 新旧版本的网络栈命名差异，导致 WAN 接口名称不同（不同于文档中的 `eth0.x`，可能会显示名称为`wan`），容易引起误导。此更改实现了 OpenWrt 或 ImmortalWrt 环境的 WAN 接口名称的自动匹配，无需在路由器后台记住任何东西。
此更改在仙林校区测试可用。
<img width="728" height="372" alt="PixPin_2026-02-27_20-04-23" src="https://github.com/user-attachments/assets/6d301a59-4e9e-4ea8-8ffe-5609499b8706" />
